### PR TITLE
Fixing one failing test in CI build

### DIFF
--- a/kged/cypress/integration/roomtest.js
+++ b/kged/cypress/integration/roomtest.js
@@ -221,7 +221,7 @@ describe('Furniture & play testing', function() {
         cy.get('.disabled').contains('Lopeta')
     })
     it('opens the interaction dialogue by clicking the furniture in game', () => {
-        cy.get('div').contains('Käynnistä').click()
+        cy.get('.pre-controls > :nth-child(1)').click()
         cy.get("[id='container']").trigger('mousedown', { clientX: 200, clientY: 200 })
     })
 


### PR DESCRIPTION
@evktalo The last test actually failed because cypress was trying to "click" the text in "käynnistä", which didn't start the game. I fixed the test to point to the button element and not the text and the game starts as expected. Test passes now.