### PR TITLE
FR: Show list of furnitures belonging to a room

### DIFF
--- a/kged/cypress/integration/roomtest.js
+++ b/kged/cypress/integration/roomtest.js
@@ -241,7 +241,7 @@ describe('Furniture & play testing', function() {
     })
     it('Checks that the furniture is listed in the room', () => {
         cy.get('div').should('have.class', 'side-nav-item').contains('Huoneet').click()
-        cy.get(':nth-child(3) > .listitem-name').contains('huoneA').click()
+        cy.get('.list-container').contains('huoneA').click()
         cy.get('p').contains('huonekalu321')
     })
     it('adds the x and y attributes', () => {

--- a/kged/cypress/integration/roomtest.js
+++ b/kged/cypress/integration/roomtest.js
@@ -150,6 +150,14 @@ describe('Name change tests', function() {
     it('Initial game name is set to Kiigame', function() {
         cy.get('.game-name').should('have.value', 'Kiigame')
     })
+    it('Checks that the name of the game cannot be empty', () => {
+        const stub = cy.stub()
+        cy.get('.game-name').clear()
+        cy.on('window:alert', stub)
+        cy.get('div').contains('Tallenna').click().then(() => {
+            expect(stub.getCall(0)).to.be.calledWith('Pelin nimi ei voi olla tyhjä!')      
+          })
+    })
     it('changes the name of the game', () => {
         cy.get('.game-name').clear().type('pelinimi')
         cy.get('.game-name').should('have.value', 'pelinimi')

--- a/kged/src/components/titlebar.jsx
+++ b/kged/src/components/titlebar.jsx
@@ -17,8 +17,8 @@ export class TitleBar extends React.Component{
     render() {
         return (
             <div>
-                <form>
-                    <label>Pelin nimi</label><br/>
+                <form onSubmit={event => {event.preventDefault()}}>
+                    <label className="text-label">Pelin nimi:</label>
                     <input className="game-name" type="text" onChange={this.onChangeHandler} value={this.props.gameName} />
                 </form>
             </div>

--- a/kged/src/styles/titlebar.scss
+++ b/kged/src/styles/titlebar.scss
@@ -5,3 +5,7 @@ input[type=text] {
     color: white;
     border: 3px solid $color-gray-800;
   }
+
+.text-label {
+  margin-right: 5px;
+}


### PR DESCRIPTION
This pull request addresses issue #23 

When user sets a furniture to a room, name of that furniture will be listed in the inspector of the selected room. If there is no furnitures in the room, there will be a text informing this to the user.