### PR TITLE
Fixing bugs caused by furniture or item having same name as room

### DIFF
--- a/kged/cypress/integration/roomtest.js
+++ b/kged/cypress/integration/roomtest.js
@@ -191,6 +191,28 @@ describe('Name change tests', function() {
     })
 })
 
+describe('Testing entity names', function() {
+    it('checks that room and furniture cannot have same name', () => {
+        cy.get('.create-new-btn').click()
+        cy.get('input[name="name"]').type('huone123')
+        cy.get('.btn-success').contains('Lisää huone').click()
+        cy.get('div').contains('huone123')
+
+        cy.get('div').should('have.class', 'side-nav-item').contains('Huonekalut').click()
+        cy.get('.create-new-btn').click()
+        cy.get("[type='name']").first().type('huone123')
+        cy.get("[type='submit']").first().click()
+        cy.get('div').contains('Nimi on jo käytössä')
+    })
+    it('checks that room and item cannot have same name', () => {
+        cy.get('div').should('have.class', 'tab-list-item col side-nav-item').contains('Esineet').click()
+        cy.get('.create-new-btn').click()
+        cy.get("[type='name']").first().type('huone123')
+        cy.get("[type='submit']").first().click()
+        cy.get('div').contains('Nimi on jo käytössä')
+    })
+})
+
 describe('Furniture & play testing', function() {
     it('creates a furniture', () => {
         cy.get('div').should('have.class', 'side-nav-item').contains('Huonekalut').click()
@@ -268,3 +290,5 @@ describe('Furniture & play testing', function() {
         cy.get("[id='container']").trigger('mousedown', { clientX: 200, clientY: 200 })
     })
 })
+
+

--- a/kged/src/actions/furnitures.js
+++ b/kged/src/actions/furnitures.js
@@ -50,6 +50,9 @@ export const setFurnitureImage = (furnitureId, filePath, objectUrl) => {
 
 export const addFurniture = (furniture) => {
     return (dispatch, getState) => {
+        if (isExistingEntity(getState(), furniture.name)) {
+            throw new DuplicateEntityError('Nimi on jo käytössä')
+        }
         dispatch({
             type: 'ADD_FURNITURE',
             payload: {

--- a/kged/src/actions/items.js
+++ b/kged/src/actions/items.js
@@ -49,6 +49,9 @@ export const setItemImage = (itemId, filePath, objectUrl) => {
 
 export const addItem = (item) => {
     return (dispatch, getState) => {
+        if (isExistingEntity(getState(), item.name)) {
+            throw new DuplicateEntityError('Nimi on jo käytössä')
+        }
         dispatch({
             type: 'ADD_ITEM',
             payload: {


### PR DESCRIPTION
This pull request addresses issues #9  and #10

It makes it so that you cannot have same name between room, item or furniture. I also made some tests for it.
